### PR TITLE
Getting rid of the need for checking the equipped property for each precept

### DIFF
--- a/Precept57/Precept.cs
+++ b/Precept57/Precept.cs
@@ -15,7 +15,6 @@ namespace Precept57
         public abstract string Scene { get; }
         public abstract float X { get; }
         public abstract float Y { get; }
-        public bool Equipped() => PlayerData.instance.GetBool(Id);
         public abstract PreceptSettings Settings(SaveSettings s);
 
         public virtual void Hook() {}

--- a/Precept57/Precept57.cs
+++ b/Precept57/Precept57.cs
@@ -1,6 +1,7 @@
 ﻿using Modding;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UObject = UnityEngine.Object;
 using ItemChanger;
@@ -45,8 +46,6 @@ namespace Precept57
                 Func<SaveSettings, PreceptSettings> settings = precept.Settings;
                 PopulateHookDictionaries(precept, settings);
 
-                precept.Hook();
-                
                 var preceptItem = CreatePrecept(precept, sprite);
                 ConfigureMapMod(preceptItem);
             }
@@ -118,9 +117,11 @@ namespace Precept57
         
         private bool SetPreceptBools(string name, bool orig)
         {
-            if (BoolSetters.TryGetValue(name, out var f))
+            var precept = Precepts.FirstOrDefault(precept => precept.Id == name);
+            if (BoolSetters.TryGetValue(name, out var f) && precept != null)
             {
                 f(orig);
+                precept.Hook();
             }
             return orig;
         }

--- a/Precept57/Precepts/Precept35.cs
+++ b/Precept57/Precepts/Precept35.cs
@@ -31,17 +31,14 @@ namespace Precept57
 
         public override void Hook()
         {
-            ModHooks.SetPlayerBoolHook += AddText;
+            AddUpAndDownText();
             UnityEngine.SceneManagement.SceneManager.activeSceneChanged += DestroyText;
             ModHooks.SavegameLoadHook += AddTextAfterLoad;
         }
 
         private void AddTextAfterLoad(int obj)
         {
-            if (Equipped())
-            {
-                AddUpAndDownText();
-            }
+            AddUpAndDownText();
         }
 
         private void DestroyText(Scene arg0, Scene scene)
@@ -50,16 +47,6 @@ namespace Precept57
             {
                 Object.Destroy(canvas);
             }
-        }
-
-        private bool AddText(string name, bool orig)
-        {
-            if (name == Id && orig)
-            {
-                AddUpAndDownText();
-            }
-            
-            return orig;
         }
 
         private void AddUpAndDownText()

--- a/Precept57/Precepts/Precept9.cs
+++ b/Precept57/Precepts/Precept9.cs
@@ -57,26 +57,20 @@ namespace Precept57
 
         private string CalculateLitterTax(string new_scene)
         {
-            if (Equipped())
-            {
-                int numSmallGeos = numActiveGeo("Geo Small(Clone)");
-                int numMediumGeos = numActiveGeo("Geo Med(Clone)");
-                int numLargeGeos = numActiveGeo("Geo Large(Clone)");
-                tax = numSmallGeos + 5 * numMediumGeos + 25 * numLargeGeos;
-                Log($"LITTER TAX: {tax}");
+            int numSmallGeos = numActiveGeo("Geo Small(Clone)");
+            int numMediumGeos = numActiveGeo("Geo Med(Clone)");
+            int numLargeGeos = numActiveGeo("Geo Large(Clone)");
+            tax = numSmallGeos + 5 * numMediumGeos + 25 * numLargeGeos;
+            Log($"LITTER TAX: {tax}");
                 
-            }
             return new_scene;
         }
 
         private void ApplyLitterTax(Scene prevScene, Scene newScene)
         {
-            if (Equipped() && tax > 0)
-            {
-                int player_geo = PlayerData.instance.GetInt("geo");
-                ItemChanger.GeoCost cost = new(tax < player_geo ? tax : player_geo);
-                cost.OnPay();
-            }
+            int player_geo = PlayerData.instance.GetInt("geo");
+            ItemChanger.GeoCost cost = new(tax < player_geo ? tax : player_geo);
+            cost.OnPay();
         }
     }
 }

--- a/Precept57/Precepts/Precept9.cs
+++ b/Precept57/Precepts/Precept9.cs
@@ -68,9 +68,12 @@ namespace Precept57
 
         private void ApplyLitterTax(Scene prevScene, Scene newScene)
         {
-            int player_geo = PlayerData.instance.GetInt("geo");
-            ItemChanger.GeoCost cost = new(tax < player_geo ? tax : player_geo);
-            cost.OnPay();
+            if (tax > 0)
+            {
+                int player_geo = PlayerData.instance.GetInt("geo");
+                ItemChanger.GeoCost cost = new(tax < player_geo ? tax : player_geo);
+                cost.OnPay();
+            }
         }
     }
 }


### PR DESCRIPTION
This makes it so that the precept hooks are only set when the precept is picked up. This is done by calling the precept hook inside our `SetPreceptBools` function which is tied to the `SetPlayerBoolHook` mod hook. Any new precepts moving forward do not require making the equipped check